### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ app.use(webpackMiddleware(webpack({
 		// but it will work with other paths too.
 	}
 }), {
-	// all options optional
+	// publicPath is required, whereas all other options are optional 
 
 	noInfo: false,
 	// display no info to console (only warnings and errors)


### PR DESCRIPTION
publicPath option should be stated as required (instead of optional), as stated on the webpack docs: https://webpack.github.io/docs/webpack-dev-middleware.html
